### PR TITLE
Call them loading tips instead of tooltips

### DIFF
--- a/Distribution/GameData/REPOSoftTech/LoadingTipsPlus/Localization.cfg
+++ b/Distribution/GameData/REPOSoftTech/LoadingTipsPlus/Localization.cfg
@@ -1,8 +1,8 @@
 Localization
 {
 	en-us
-	{		
-		#autoLOC_LTIPSPLUS_0001 = Tooltips brought to you by LoadingToolTipsPlus...			
+	{
+		#autoLOC_LTIPSPLUS_0001 = Loading tips brought to you by LoadingTipsPlus...
 	}
 }
 
@@ -10,7 +10,7 @@ Localization
 {
 	es-es
 	{
-		#autoLOC_LTIPSPLUS_0001 = Tooltips brought to you by LoadingToolTipsPlus...		
+		#autoLOC_LTIPSPLUS_0001 = Loading tips brought to you by LoadingTipsPlus...
 	}
 }
 
@@ -18,7 +18,7 @@ Localization
 {
 	es-mx
 	{
-		#autoLOC_LTIPSPLUS_0001 = Tooltips brought to you by LoadingToolTipsPlus...		
+		#autoLOC_LTIPSPLUS_0001 = Loading tips brought to you by LoadingTipsPlus...
 	}
 }
 
@@ -26,7 +26,7 @@ Localization
 {
 	ja
 	{
-		#autoLOC_LTIPSPLUS_0001 = Tooltips brought to you by LoadingToolTipsPlus...		
+		#autoLOC_LTIPSPLUS_0001 = Loading tips brought to you by LoadingTipsPlus...
 	}
 }
 
@@ -34,7 +34,7 @@ Localization
 {
 	ru
 	{
-		#autoLOC_LTIPSPLUS_0001 = Tooltips brought to you by LoadingToolTipsPlus...		
+		#autoLOC_LTIPSPLUS_0001 = Loading tips brought to you by LoadingTipsPlus...
 	}
 }
 
@@ -42,6 +42,6 @@ Localization
 {
 	zh-cn
 	{
-		#autoLOC_LTIPSPLUS_0001 = Tooltips brought to you by LoadingToolTipsPlus...		
+		#autoLOC_LTIPSPLUS_0001 = Loading tips brought to you by LoadingTipsPlus...
 	}
 }


### PR DESCRIPTION
The example loading tips call themselves Tooltips and call the mod LoadingToolTipsPlus. This pull request changes them to Loading tips and LoadingTipsPlus.